### PR TITLE
 #4: add support for centos

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
 - import_tasks: package.yml
-  when: ansible_distribution == "Debian"
-
 - import_tasks: oh-my-zsh.yml
 - import_tasks: shell.yml

--- a/tasks/oh-my-zsh.yml
+++ b/tasks/oh-my-zsh.yml
@@ -2,6 +2,10 @@
 - name: ensure oh-my-zsh is installed and configured
   block:
 
+  - file:
+      path: "/etc/zsh"
+      state: "directory"
+
   - name: ensure oh-my-zsh repository is cloned
     git:
       repo: "{{ oh_my_zsh_repository }}"
@@ -14,5 +18,15 @@
     with_items:
       - { src: "zshrc.j2", dest: "/etc/zsh/zshrc" }
       - { src: "zshenv.j2", dest: "/etc/zsh/zshenv" }
+
+  - file:
+      src: "{{ item.src }}"
+      dest: "{{ item.dest }}"
+      force: true
+      state: "link"
+    with_items:
+      - { src: "/etc/zsh/zshenv", dest: "/etc/zshenv" }
+      - { src: "/etc/zsh/zshrc", dest: "/etc/zshrc" }
+    when: ansible_distribution == 'CentOS'
 
   become: true

--- a/tasks/package.yml
+++ b/tasks/package.yml
@@ -10,3 +10,14 @@
     - git
     - zsh
   become: true
+  when: ansible_distribution == 'Debian'
+
+- name: ensure git and zfs packages are installed
+  yum:
+    name: "{{ item }}"
+    state: "present"
+  with_items:
+    - git
+    - zsh
+  become: true
+  when: ansible_distribution == 'CentOS'

--- a/tasks/shell.yml
+++ b/tasks/shell.yml
@@ -7,3 +7,4 @@
     - "{{ ansible_env.USER }}"
     - "root"
   become: true
+  ignore_errors: true


### PR DESCRIPTION
 - ensure existence of /etc/zsh directory
 - create symlinks from /etc/zsh/{zshrc,zshenv} to /etc
 - condition and limit installation package script to centos
 - allow shell change to zsh fail (for sssd/ldap/cas users)